### PR TITLE
Fix minor inconsistency in Code-Conventions.md IntelliJ Imports section

### DIFF
--- a/Code-Conventions.md
+++ b/Code-Conventions.md
@@ -97,7 +97,7 @@ After installing and restarting IDEA, then go to File->Settings->Tools->Checksty
 
 We also don't like overhaul of wildcard imports, so please turn those off
 1. By changing `Class count to use import with '*'` to 999
-2. By changing `Names count to use static imports with '*'` to 10 (static imports for f.e. ItemIDs with wildcards are preferred)
+2. By changing `Names count to use static imports with '*'` to 999 (static imports for f.e. ItemIDs with wildcards are preferred)
 
 See screenshot below for correct values for mentioned 2 fields.
 

--- a/Code-Conventions.md
+++ b/Code-Conventions.md
@@ -97,7 +97,7 @@ After installing and restarting IDEA, then go to File->Settings->Tools->Checksty
 
 We also don't like overhaul of wildcard imports, so please turn those off
 1. By changing `Class count to use import with '*'` to 999
-2. By changing `Names count to use static imports with '*'` to 999 (static imports, e.g. ItemIDs with wildcards are preferred)
+2. By changing `Names count to use static imports with '*'` to 999 (static imports, e.g. ItemIDs with wildcards, are preferred)
 
 See screenshot below for correct values for mentioned 2 fields.
 

--- a/Code-Conventions.md
+++ b/Code-Conventions.md
@@ -97,7 +97,7 @@ After installing and restarting IDEA, then go to File->Settings->Tools->Checksty
 
 We also don't like overhaul of wildcard imports, so please turn those off
 1. By changing `Class count to use import with '*'` to 999
-2. By changing `Names count to use static imports with '*'` to 999 (static imports for f.e. ItemIDs with wildcards are preferred)
+2. By changing `Names count to use static imports with '*'` to 999 (static imports, e.g. ItemIDs with wildcards are preferred)
 
 See screenshot below for correct values for mentioned 2 fields.
 

--- a/Code-Conventions.md
+++ b/Code-Conventions.md
@@ -97,7 +97,7 @@ After installing and restarting IDEA, then go to File->Settings->Tools->Checksty
 
 We also don't like overhaul of wildcard imports, so please turn those off
 1. By changing `Class count to use import with '*'` to 999
-2. By changing `Names count to use static imports with '*'` to 999 (static imports, e.g. ItemIDs with wildcards, are preferred)
+2. By changing `Names count to use static imports with '*'` to 999 (static imports, for example ItemIDs with wildcards, are preferred)
 
 See screenshot below for correct values for mentioned 2 fields.
 


### PR DESCRIPTION
See: https://github.com/runelite/runelite/wiki/Code-Conventions#imports

The modification to the `Names count to use static imports with '*'` field, described in the `## Imports` section didn't match the screenshot below it (https://i.imgur.com/XlJzIKv.png).

Talking to Adam on Discord to figure out which was the correct setting, he said:

> usually 999
> the problem is if it star imports eg ItemID or something, intellij typically gets sluggish because the file has so many fields
> and so you want to make it avoid that

Warning: This is my first PR, so please let me know if I've missed any steps in the pull request process.