### PR TITLE
document `::commands`

### DIFF
--- a/Time-Tracking.md
+++ b/Time-Tracking.md
@@ -7,3 +7,10 @@
 ### 1. Show Relative Time
 
 (Default Off) When enabled, instead of showing you what time your harvest will be ready ("Done at 17:40"), it will show you how long until your harvest is ready ("Done in 1h 30m").
+
+
+
+## `::resetfarmtick` Chat Command
+
+In rare cases where the timers for farming patches get desynced, you can type `::resetfarmtick` into the games chatbox to reset the timers.
+Standing by a wood tree patch and seeing it grow will restore the timers.

--- a/World-Hopper.md
+++ b/World-Hopper.md
@@ -22,3 +22,7 @@ Toggles whether to hop to a PVP/high risk world when quick-hopping
 Toggles whether the world hopper panel should be added to the sidebar
 
 ![world hopper sidebar](https://user-images.githubusercontent.com/2199511/45316291-35280500-b526-11e8-915b-d881c694adfa.png)
+
+### Quick-hop Chat Command
+
+`::hop <world-number>` can be typed into the games chatbox to hop to the specified world (e.g. `::hop 321` to hop to world 321)


### PR DESCRIPTION
Documents both `::commands` that are not restricted in their usage by dev mode

Closes #45