### PR TITLE
Rejected-Features: add touchscreen/controller plugins

### DIFF
--- a/Rejected-or-Rolled-Back-Features.md
+++ b/Rejected-or-Rolled-Back-Features.md
@@ -26,6 +26,7 @@ Jagex has requested removal of certain features, and current discussion of featu
 * Hiscores for PBs and other information not on the hiscores: Same as the GE Tracker, the data could easily be spoofed, rendering it useless. 
 * Presets for Camera yaw/pitch/position
 * Auto-rejoin for parties: Would put undue strain on the party servers.
+* Touchscreen/Controller plugins: Any plugin-hub implementations of this would likely trigger Jagex's macro detection, and thus won't be accepted.  
 
 #### Menu Entry Swapping
 * `Build/Remove` on POH hotspots: [see Jagex statement](https://secure.runescape.com/m=news/third-party-client-guidelines?oldschool=1) (Try [this method](https://www.youtube.com/watch?v=u9AZWsDfo1I) instead)


### PR DESCRIPTION
2 different touchscreen and one controller plugin were all PR'd in a short window, and another user came into the discord asking about touchscreen issues recently, so I've gone ahead and added a note rejecting them as a hub plugin.