### PR TITLE
slayer: update page to reflect changes in task tracking

### DIFF
--- a/Slayer.md
+++ b/Slayer.md
@@ -9,10 +9,5 @@ When checked, this will add your remaining slayer task amount to slayer helms an
 ### Task Infobox
 When checked, this will display your task in an infobox to the top-left of the game window  
 ![Task infobox](https://i.imgur.com/KKa1hut.png)  
-Along with a mouse tooltip on hover containing your points and streak  
+Along with a mouse tooltip on hover containing your points, streak and designated location if assigned one.  
 ![Task points and streak tooltip](https://i.imgur.com/7lXCMeu.png)
-
-Note that RuneLite gets the information on your Slayer task when you receive the task or when you check the Slayer gem. RuneLite keeps its own counter for display in the infobox. This also means RuneLite's counter can become out of sync with the real counter, for instance when you make a few kills when not using RuneLite.
-
-### Bursting and Cannons
-Runelite currently gets kill count information based on your xp drops so if you manage to kill multiple enemies in the same tick Runelite can only register that as one kill which will get out of sync if doing bursting or cannoning a task.

--- a/Slayer.md
+++ b/Slayer.md
@@ -9,5 +9,5 @@ When checked, this will add your remaining slayer task amount to slayer helms an
 ### Task Infobox
 When checked, this will display your task in an infobox to the top-left of the game window  
 ![Task infobox](https://i.imgur.com/KKa1hut.png)  
-Along with a mouse tooltip on hover containing your points, streak and designated location if assigned one.  
+Placing your mouse over this infobox will display your points, streak, and designated location if assigned one.  
 ![Task points and streak tooltip](https://i.imgur.com/7lXCMeu.png)


### PR DESCRIPTION
These issues were resolved since the slayer plugin no longer tracks/stores task information locally but instead relies on vars.