### PR TITLE
Building with IntelliJ: Add note about being for core development

### DIFF
--- a/Building-with-IntelliJ-IDEA.md
+++ b/Building-with-IntelliJ-IDEA.md
@@ -1,4 +1,6 @@
 <!-- omit in toc -->
+This guide is for core client development. For plugin hub development, see [[Developer Guide]].
+
 # Table of Contents
 
 - [Getting started](#getting-started)


### PR DESCRIPTION
Adds a note specifying that the guide is for core development and directs hub devs to the Developer Guide.

There have been a fair number of people trying to use this guide for hub development so the note seemed warranted