### PR TITLE
Rejected-Features: add plugins which expose player information over http to list of features not being considered

### DIFF
--- a/Rejected-or-Rolled-Back-Features.md
+++ b/Rejected-or-Rolled-Back-Features.md
@@ -28,7 +28,8 @@ Jagex has requested removal of certain features, and current discussion of featu
 * Auto-rejoin for parties: Would put undue strain on the party servers.
 * Touchscreen/Controller plugins: Any plugin-hub implementations of this would likely trigger Jagex's macro detection, and thus won't be accepted.  
 * ID based plugins: Plugins that use player provided IDs for the entirety of their functionality can cause moderation issues and outcomes that break Jagex's plugin rules. Due to this fact we will not be accepting any new ID based plugins. Plugins that use a specific set of IDs but do not allow user input will still be accepted. (e.g. plugins like Vardorvis Projectiles which only allows you to change a specific projectile to a set list of projectiles.)  
-* Twitch/BTTV/FFZ/7TV emote plugins: Distributing the emotes for these plugins would likely require skirting over the legal agreements of these services, and thus won't be accepted.  
+* Twitch/BTTV/FFZ/7TV emote plugins: Distributing the emotes for these plugins would likely require skirting over the legal agreements of these services, and thus won't be accepted.
+* Plugins which expose player information over HTTP.
 
 #### Menu Entry Swapping
 * `Conditional menu entry removing`: This can be overpowered in some cases (hiding attack options on NPCs/players based on some conditions, like it being friend or it being specific type of NPC).


### PR DESCRIPTION
As mentioned by Adam [here](https://togithub.com/runelite/plugin-hub/pull/6200#issuecomment-2183182026).