### PR TITLE
timers: remove outdated list of available timers

### DIFF
--- a/Timers.md
+++ b/Timers.md
@@ -1,2 +1,2 @@
 ## Timers Configuration
-The Timers plugin will show various timers in an infobox to the top left of the game window, and all timers can be switched on or off. Please refer to the config for more information.
+The Timers plugin will show various timers in an infobox, all of these timers can be switched on or off. Please refer to the Timers plugin settings for the list of available timers.

--- a/Timers.md
+++ b/Timers.md
@@ -1,20 +1,2 @@
 ## Timers Configuration
-The Timers plugin will show various timers in an infobox to the top left of the game window, and all timers can be switched on or off  
-
-The current timers available are:  
-* Antifire (+ extended)
-* Superantifire (+ extended)
-* Antidote+ (and ++)
-* Anti-venom (and +)
-* Stamina
-* Sanfew Serum
-* Overload (NMZ and raids)
-* Prayer Enhance (raids)
-* Cannon
-* Imbued Heart
-* Vengeance 
-* Magic Imbue
-* Freezes (Bind, Snare, Entangle, Ice spells)
-* Teleblock (full and half)
-* Tzhaar (Inferno and Fight Caves)
-
+The Timers plugin will show various timers in an infobox to the top left of the game window, and all timers can be switched on or off. Please refer to the config for more information.


### PR DESCRIPTION
Removes the outdated list of available timers. We're not going to keep updating this list, so it'll likely always be outdated. Additionally, there's no reason for this list to exist; you can perfectly see it in the timers config, and the config contains way more useful info than this list.