### PR TITLE
Add missing linebreak after lunar chest.

### DIFF
--- a/Chat-Commands.md
+++ b/Chat-Commands.md
@@ -122,7 +122,7 @@ Some boss names can be substituted for shorthand versions:
 `wisp`, `whisp`, `the whisperer` -> `Whisperer`  
 `wisp awakened`, `whisp awakened`, `whisperer awakened` -> `Whisperer (awakened)`  
 `barrows` -> `Barrows Chests`  
-`lunar chests`, `moons of peril`, `perilous moon`, `perilous moons` -> `Lunar Chest`
+`lunar chests`, `moons of peril`, `perilous moon`, `perilous moons` -> `Lunar Chest`  
 `gaunt`, `the gauntlet` -> `Gauntlet`  
 `cg`, `cgaunt`, `cgauntlet`, `the corrupted gauntlet` -> `Corrupted Gauntlet`  
 `jad`, `tzhaar fight cave` -> `TzTok-Jad`  


### PR DESCRIPTION
Lunar Chest and (regular) gauntlet was on the same line.