### PR TITLE
update macOS build instructions

### DIFF
--- a/Building-with-IntelliJ-IDEA.md
+++ b/Building-with-IntelliJ-IDEA.md
@@ -52,7 +52,7 @@ When first viewing the project in IntelliJ IDEA you may come across this error:
 
 This is because you do not have the [Lombok Plugin](https://plugins.jetbrains.com/plugin/6317-lombok-plugin) installed.
 
-Navigate to the `Plugins` tab under the `(Main Menu) > File > Settings` menu (`IntelliJ IDEA > Preferences` for Mac). Click the `Marketplace` button and search for **Lombok** to find it. Install the plugin and restart IntelliJ IDEA.
+Navigate to the `Plugins` tab under the `(Main Menu) > File > Settings` menu (`IntelliJ IDEA > Settings...` or `⌘` + `,` for Mac). Click the `Marketplace` button and search for **Lombok** to find it. Install the plugin and restart IntelliJ IDEA.
 
 ![installing_lombok.png](img/building-with-intellij/installing_lombok.png)
 


### PR DESCRIPTION
IntelliJ on macOS no longer refers to its settings menu as `Preferences`

![image](https://github.com/user-attachments/assets/34ec1947-8ab6-4856-99e2-d7073e9c71fb)
